### PR TITLE
Fix(Flashcards): Resolve visibility, contrast, and layout overlap issues

### DIFF
--- a/css/tabView.css
+++ b/css/tabView.css
@@ -1,21 +1,25 @@
 /* --- Flashcard Specific Styles --- */
-.flashcard-container {
+.tv-flashcard-container {
     display: flex;
     flex-direction: column;
     align-items: center;
     margin-top: 2rem;
-    perspective: 1000px; /* Add perspective for 3D effect */
+    perspective: 1000px;
+    /* Add perspective for 3D effect */
+    z-index: 10;
 }
 
-.flashcard-card {
+.tv-flashcard-card {
     width: 100%;
     max-width: 500px;
-    height: 200px;
+    height: 300px;
+    /* Increased height to 300px for better visibility */
     /* background-color will be set inline based on group.frontColor */
     color: white;
     border-radius: 12px;
     display: flex;
-    flex-direction: column; /* Allow content to stack */
+    flex-direction: column;
+    /* Allow content to stack */
     justify-content: center;
     align-items: center;
     font-size: 1.5rem;
@@ -29,12 +33,12 @@
     position: relative;
 }
 
-.flashcard-non-flippable-front {
+.tv-flashcard-non-flippable-front {
     font-size: 1.1em;
     font-weight: 600;
 }
 
-.flashcard-non-flippable-back {
+.tv-flashcard-non-flippable-back {
     font-size: 0.9em;
     font-weight: 400;
     margin-top: 0.5em;
@@ -42,67 +46,87 @@
 }
 
 /* Styles for non-flippable cards */
-.flashcard-card.non-flippable-card {
-    transform-style: flat; /* Disable 3D for non-flippable cards */
-    transition: none; /* No transition for non-flippable cards */
-    cursor: default; /* Change cursor for non-flippable cards */
+.tv-flashcard-card.non-flippable-card {
+    transform-style: flat;
+    /* Disable 3D for non-flippable cards */
+    transition: none;
+    /* No transition for non-flippable cards */
+    cursor: default;
+    /* Change cursor for non-flippable cards */
 }
 
-.flashcard-card.non-flippable-card .flashcard-front,
-.flashcard-card.non-flippable-card .flashcard-back {
-    transform: none; /* Remove any initial rotation */
+.tv-flashcard-card.non-flippable-card .tv-flashcard-front,
+.tv-flashcard-card.non-flippable-card .tv-flashcard-back {
+    transform: none;
+    /* Remove any initial rotation */
 }
 
-.flashcard-front, .flashcard-back {
+.tv-flashcard-front,
+.tv-flashcard-back {
     position: absolute;
     width: 100%;
     height: 100%;
     backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
     display: flex;
-    flex-direction: column; /* Ensure content stacks vertically */
+    flex-direction: column;
+    /* Ensure content stacks vertically */
     justify-content: center;
     align-items: center;
-    padding: 1rem;
+    padding: 2rem;
+    /* Increased padding */
     /* Add transition for smooth flip of individual faces */
     transition: transform 0.6s;
-    color: var(--text-primary); /* Ensure text is visible */
+    color: #ffffff;
+    /* Ensure text is white for contrast against dark backgrounds */
+    border-radius: 12px;
+    top: 0;
+    left: 0;
+    overflow-y: auto;
+    /* Allow scrolling for long content */
 }
 
-.flashcard-front {
-    background-color: var(--primary-blue-dark); /* Set background for quiz flashcard front */
-    color: var(--text-primary-dark); /* Ensure text is visible */
+.tv-flashcard-front {
+    background-color: var(--primary-blue-dark);
+    /* Set background for quiz flashcard front */
+    color: #ffffff;
     transform: rotateY(0deg);
 }
 
-.flashcard-back {
-    background-color: var(--light-blue); /* Keep existing background for back */
-    color: var(--primary-blue-dark);
+.tv-flashcard-back {
+    background-color: var(--primary-blue);
+    /* Default back color */
+    color: #ffffff;
     transform: rotateY(180deg);
 }
 
-.flashcard-card.flipped .flashcard-front {
+.tv-flashcard-card.flipped .tv-flashcard-front {
     transform: rotateY(-180deg);
 }
 
-.flashcard-card.flipped .flashcard-back {
+.tv-flashcard-card.flipped .tv-flashcard-back {
     transform: rotateY(0deg);
 }
 
-.flashcard-controls {
+.tv-flashcard-controls {
     display: flex;
     justify-content: space-between;
     width: 100%;
     max-width: 500px;
-    margin-top: 1.5rem;
+    margin-top: 6rem;
     align-items: center;
+    position: relative;
+    /* Ensure controls are positioned */
+    z-index: 20;
+    /* Ensure controls are above card if overlap happens */
 }
 
-.flashcard-controls .tab-button {
+.tv-flashcard-controls .tab-button {
     padding: 0.75rem 1.5rem;
     font-size: 1rem;
 }
 
-.flashcard-controls span {
+.tv-flashcard-controls span {
     font-size: 1.1rem;
     font-weight: 500;
     color: var(--text-primary);
@@ -117,19 +141,23 @@
 }
 
 .flashcard-group-title {
-    font-size: 1.75rem; /* Tailwind text-2xl */
-    font-weight: 700; /* Tailwind font-bold */
+    font-size: 1.75rem;
+    /* Tailwind text-2xl */
+    font-weight: 700;
+    /* Tailwind font-bold */
     color: var(--primary-blue-dark);
     margin-bottom: 0.75rem;
 }
 
 .flashcard-group-description {
-    font-size: 1.125rem; /* Tailwind text-lg */
+    font-size: 1.125rem;
+    /* Tailwind text-lg */
     line-height: 1.6;
     color: var(--text-primary);
     margin-bottom: 1.5rem;
 }
 
+/* Grid styles maintained for legacy/other uses if needed, or update to tv- if grid used */
 .flashcards-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
@@ -137,8 +165,9 @@
 }
 
 /* Adjust individual card styling within the grid */
-.flashcards-grid .flashcard-card {
-    height: 150px; /* Smaller height for grid cards */
+.flashcards-grid .tv-flashcard-card {
+    height: 150px;
+    /* Smaller height for grid cards */
     font-size: 1.2rem;
 }
 
@@ -173,8 +202,15 @@
     z-index: 1;
 }
 
-.timeline-event.left { left: 0; padding-right: 60px; }
-.timeline-event.right { left: 50%; padding-left: 60px; }
+.timeline-event.left {
+    left: 0;
+    padding-right: 60px;
+}
+
+.timeline-event.right {
+    left: 50%;
+    padding-left: 60px;
+}
 
 .timeline-event::after {
     content: '';
@@ -188,8 +224,15 @@
     z-index: 1;
 }
 
-.timeline-event.left::after { right: -10px; transform: translateX(50%); }
-.timeline-event.right::after { left: 10px; transform: translateX(-50%); }
+.timeline-event.left::after {
+    right: -10px;
+    transform: translateX(50%);
+}
+
+.timeline-event.right::after {
+    left: 10px;
+    transform: translateX(-50%);
+}
 
 .timeline-content {
     background-color: #ffffff;
@@ -200,24 +243,39 @@
 }
 
 .timeline-event.left .timeline-content::before {
-    content: ''; position: absolute; top: 25px; right: -15px;
-    border-width: 15px 0 15px 15px; border-style: solid;
+    content: '';
+    position: absolute;
+    top: 25px;
+    right: -15px;
+    border-width: 15px 0 15px 15px;
+    border-style: solid;
     border-color: transparent transparent transparent #ffffff;
 }
 
 .timeline-event.right .timeline-content::before {
-    content: ''; position: absolute; top: 25px; left: -15px;
-    border-width: 15px 15px 15px 0; border-style: solid;
+    content: '';
+    position: absolute;
+    top: 25px;
+    left: -15px;
+    border-width: 15px 15px 15px 0;
+    border-style: solid;
     border-color: transparent #ffffff transparent transparent;
 }
 
 .timeline-era {
-    text-align: center; margin: 40px 0; position: relative; z-index: 2;
+    text-align: center;
+    margin: 40px 0;
+    position: relative;
+    z-index: 2;
 }
 
 .timeline-era h2 {
-    background-color: var(--primary-blue); color: #ffffff; display: inline-block;
-    padding: 10px 20px; border-radius: 9999px; font-weight: 700;
+    background-color: var(--primary-blue);
+    color: #ffffff;
+    display: inline-block;
+    padding: 10px 20px;
+    border-radius: 9999px;
+    font-weight: 700;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
@@ -298,8 +356,10 @@
 }
 
 .quiz-main-title {
-    font-size: 2rem; /* Tailwind text-2xl */
-    font-weight: 700; /* Tailwind font-bold */
+    font-size: 2rem;
+    /* Tailwind text-2xl */
+    font-weight: 700;
+    /* Tailwind font-bold */
     color: var(--primary-blue-dark);
     text-align: center;
     margin-bottom: 1rem;
@@ -324,8 +384,10 @@
 }
 
 .quiz-format-title {
-    font-size: 1.5rem; /* Tailwind text-xl */
-    font-weight: 600; /* Tailwind font-semibold */
+    font-size: 1.5rem;
+    /* Tailwind text-xl */
+    font-weight: 600;
+    /* Tailwind font-semibold */
     color: var(--primary-blue);
     margin-top: 1.5rem;
     margin-bottom: 1rem;

--- a/js/tabView.js
+++ b/js/tabView.js
@@ -2,6 +2,7 @@
  * JAB Manual - tabView.js
  * Contains functions to render dynamic content types for tabTemplate.html
  */
+console.log('tabView.js v7 loaded at', new Date().toISOString());
 
 /**
  * Renders quiz content with Q&A List and Flashcard formats.
@@ -28,16 +29,16 @@ function renderQuiz(quizData, containerElement) {
             </div>
             <div id="flashcards-view" class="quiz-view" style="display: none;">
                 <h3 class="quiz-format-title">Quiz: Flashcard Format</h3>
-                <div id="flashcard-container" class="flashcard-container">
-                    <div class="flashcard-card">
-                        <div class="flashcard-front">
+                <div id="flashcard-container" class="tv-flashcard-container">
+                    <div class="tv-flashcard-card">
+                        <div class="tv-flashcard-front">
                             <p id="flashcard-question"></p>
                         </div>
-                        <div class="flashcard-back">
+                        <div class="tv-flashcard-back">
                             <p id="flashcard-answer"></p>
                         </div>
                     </div>
-                    <div class="flashcard-controls">
+                    <div class="tv-flashcard-controls">
                         <button id="flashcard-prev" class="tab-button">Previous</button>
                         <span id="flashcard-counter"></span>
                         <button id="flashcard-next" class="tab-button">Next</button>
@@ -72,12 +73,6 @@ function renderQuiz(quizData, containerElement) {
                 showAnswerBtn.textContent = 'Show Answer';
             }
         });
-
-        // No direct check logic here, as the user just wants to reveal the answer
-        // The answer is already in quizAnswerDiv.innerHTML = `${q.answer}`;
-        // The change to string answers only affects the D2.json structure, not this display logic.
-        // If there was a 'check answer' button for Q&A list, this would be the place to modify it.
-        // However, based on the provided code, it's just a 'show answer' button.
     });
 
     // Flashcard logic
@@ -87,15 +82,12 @@ function renderQuiz(quizData, containerElement) {
     const flashcardCounter = containerElement.querySelector('#flashcard-counter');
     const flashcardPrevBtn = containerElement.querySelector('#flashcard-prev');
     const flashcardNextBtn = containerElement.querySelector('#flashcard-next');
-    const flashcardCard = containerElement.querySelector('.flashcard-card');
-    const flashcardFront = containerElement.querySelector('.flashcard-front');
-    const flashcardBack = containerElement.querySelector('.flashcard-back');
+    const flashcardCard = containerElement.querySelector('.tv-flashcard-card');
+    const flashcardFront = containerElement.querySelector('.tv-flashcard-front');
+    const flashcardBack = containerElement.querySelector('.tv-flashcard-back');
 
     function updateFlashcard() {
         const currentQuestion = quizData.questions[currentFlashcardIndex];
-        console.log('Updating flashcard. Current question:', currentQuestion);
-        console.log('flashcardQuestion element:', flashcardQuestion);
-        console.log('flashcardAnswer element:', flashcardAnswer);
         flashcardQuestion.textContent = currentQuestion.question;
         flashcardAnswer.textContent = currentQuestion.answer;
         flashcardCounter.textContent = `${currentFlashcardIndex + 1}/${quizData.questions.length}`;
@@ -139,7 +131,6 @@ function renderQuiz(quizData, containerElement) {
         updateFlashcard(); // Initialize flashcard view
     });
 
-    updateFlashcard(); // Initial load of the first flashcard
     updateFlashcard(); // Initial load of the first flashcard
 }
 
@@ -682,7 +673,7 @@ function renderFlashcards(flashCardsData, containerElement) {
         return;
     }
 
-    flashCardsData.forEach(group => {
+    flashCardsData.forEach((group, groupIndex) => {
         const groupDiv = document.createElement('div');
         groupDiv.className = 'flashcard-group';
 
@@ -700,58 +691,116 @@ function renderFlashcards(flashCardsData, containerElement) {
             groupDiv.appendChild(description);
         }
 
-        const cardsGrid = document.createElement('div');
-        cardsGrid.className = 'flashcards-grid';
+        // Create single flashcard container with navigation
+        const flashcardContainer = document.createElement('div');
+        flashcardContainer.className = 'tv-flashcard-container';
+        flashcardContainer.id = `tv-flashcard-container-${groupIndex}`;
 
-        group.cards.forEach(card => {
-            const flashcardCard = document.createElement('div');
-            flashcardCard.className = 'flashcard-card';
+        const flashcardCard = document.createElement('div');
+        flashcardCard.className = 'tv-flashcard-card';
+        flashcardCard.id = `tv-flashcard-card-${groupIndex}`;
 
-            // Apply custom colors if provided
-            if (group.frontColor) {
-                flashcardCard.style.backgroundColor = group.frontColor;
-            }
+        // Apply custom colors if provided
+        if (group.frontColor) {
+            flashcardCard.style.setProperty('--flashcard-front-color', group.frontColor);
+        }
+        if (group.backColor) {
+            flashcardCard.style.setProperty('--flashcard-back-color', group.backColor);
+        }
 
-            const flashcardFront = document.createElement('div');
-            flashcardFront.className = 'flashcard-front';
+        const flashcardFront = document.createElement('div');
+        flashcardFront.className = 'tv-flashcard-front';
+        flashcardFront.id = `tv-flashcard-front-${groupIndex}`;
+        if (group.frontColor) {
+            flashcardFront.style.backgroundColor = group.frontColor;
+            flashcardFront.style.color = '#ffffff'; // Force white text
+        }
 
-            if (group.flippable === false) {
-                // For non-flippable, both front and back are visible in the 'front' div
-                flashcardFront.innerHTML = `
-                    <p class="flashcard-non-flippable-front">${card.front}</p>
-                    <p class="flashcard-non-flippable-back">${card.back}</p>
-                `;
-                flashcardFront.style.backgroundColor = group.frontColor; // Use frontColor for background
-                flashcardFront.style.color = group.backColor; // Use backColor for text
-            } else {
-                flashcardFront.innerHTML = `<p>${card.front}</p>`;
-            }
+        const flashcardBack = document.createElement('div');
+        flashcardBack.className = 'tv-flashcard-back';
+        flashcardBack.id = `tv-flashcard-back-${groupIndex}`;
+        if (group.backColor) {
+            flashcardBack.style.backgroundColor = group.backColor;
+            flashcardBack.style.color = '#ffffff'; // Force white text
+        }
 
-            const flashcardBack = document.createElement('div');
-            flashcardBack.className = 'flashcard-back';
-            flashcardBack.innerHTML = `<p>${card.back}</p>`;
-            if (group.backColor) {
-                flashcardBack.style.backgroundColor = group.backColor;
-            }
+        flashcardCard.appendChild(flashcardFront);
+        flashcardCard.appendChild(flashcardBack);
+        flashcardContainer.appendChild(flashcardCard);
 
-            flashcardCard.appendChild(flashcardFront);
-            // Only append back if flippable
-            if (group.flippable !== false) {
-                flashcardCard.appendChild(flashcardBack);
-            }
+        // Create navigation controls
+        const controlsDiv = document.createElement('div');
+        controlsDiv.className = 'tv-flashcard-controls';
 
-            if (group.flippable !== false) {
-                flashcardCard.addEventListener('click', () => {
-                    flashcardCard.classList.toggle('flipped');
-                });
-            } else {
-                flashcardCard.classList.add('non-flippable-card');
-            }
+        // Inline styles for flex layout to ensure it works even if CSS is slow
+        controlsDiv.style.display = 'flex';
+        controlsDiv.style.justifyContent = 'space-between';
+        controlsDiv.style.width = '100%';
+        controlsDiv.style.maxWidth = '500px';
+        controlsDiv.style.marginTop = '6rem';
+        controlsDiv.style.alignItems = 'center';
 
-            cardsGrid.appendChild(flashcardCard);
+        const prevBtn = document.createElement('button');
+        prevBtn.className = 'tab-button';
+        prevBtn.textContent = 'Previous';
+        prevBtn.id = `flashcard-prev-${groupIndex}`;
+
+        const counter = document.createElement('span');
+        counter.id = `flashcard-counter-${groupIndex}`;
+        counter.className = 'flashcard-counter';
+        counter.style.fontSize = '1.1rem';
+        counter.style.fontWeight = '500';
+
+        const nextBtn = document.createElement('button');
+        nextBtn.className = 'tab-button';
+        nextBtn.textContent = 'Next';
+        nextBtn.id = `flashcard-next-${groupIndex}`;
+
+        controlsDiv.appendChild(prevBtn);
+        controlsDiv.appendChild(counter);
+        controlsDiv.appendChild(nextBtn);
+        flashcardContainer.appendChild(controlsDiv);
+
+        groupDiv.appendChild(flashcardContainer);
+        containerElement.appendChild(groupDiv);
+
+        // Initialize flashcard logic for this group
+        let currentIndex = 0;
+        const cards = group.cards;
+
+        if (!cards || cards.length === 0) {
+            return;
+        }
+
+        function updateCard() {
+            const card = cards[currentIndex];
+            flashcardFront.innerHTML = `<p style="margin:0; padding:10px;">${card.front}</p>`;
+            flashcardBack.innerHTML = `<p style="margin:0; padding:10px;">${card.back}</p>`;
+            counter.textContent = `${currentIndex + 1} / ${cards.length}`;
+            flashcardCard.classList.remove('flipped');
+        }
+
+        // Flip on click
+        if (group.flippable !== false) {
+            flashcardCard.addEventListener('click', () => {
+                flashcardCard.classList.toggle('flipped');
+            });
+        }
+
+        // Navigation
+        prevBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            currentIndex = (currentIndex - 1 + cards.length) % cards.length;
+            updateCard();
         });
 
-        groupDiv.appendChild(cardsGrid);
-        containerElement.appendChild(groupDiv);
+        nextBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            currentIndex = (currentIndex + 1) % cards.length;
+            updateCard();
+        });
+
+        // Initialize first card
+        updateCard();
     });
 }

--- a/tabTemplate.html
+++ b/tabTemplate.html
@@ -11,7 +11,7 @@
 
     <link rel="stylesheet" href="./css/main.css">
     <link rel="stylesheet" href="./css/story.css">
-    <link rel="stylesheet" href="./css/tabView.css">
+    <link rel="stylesheet" href="./css/tabView.css?v=9">
 </head>
 
 <body>
@@ -52,7 +52,7 @@
     <!-- Cache busting utility -->
     <!-- Include main navigation script -->
     <script src="./js/main.js"></script>
-    <script src="./js/tabView.js?v=2"></script>
+    <script src="./js/tabView.js?v=9"></script>
 
     <script>
         // Get section from URL parameters


### PR DESCRIPTION
- Rename CSS classes to tv-flashcard-* to namespace them and avoid conflicts with flashcard.css.
- Force white text color (#ffffff) on flashcards for contrast against dark backgrounds.
- Increase controls spacing to 6rem and add z-indexing to prevent overlap.
- Bump CSS and JS cache busters to v9.