### PR TITLE
Fix build: Remove manual cache busting from tabTemplate.html

### DIFF
--- a/tabTemplate.html
+++ b/tabTemplate.html
@@ -11,7 +11,7 @@
 
     <link rel="stylesheet" href="./css/main.css">
     <link rel="stylesheet" href="./css/story.css">
-    <link rel="stylesheet" href="./css/tabView.css?v=10">
+    <link rel="stylesheet" href="./css/tabView.css">
 </head>
 
 <body>
@@ -52,7 +52,7 @@
     <!-- Cache busting utility -->
     <!-- Include main navigation script -->
     <script src="./js/main.js"></script>
-    <script src="./js/tabView.js?v=10"></script>
+    <script src="./js/tabView.js"></script>
 
     <script>
         // Get section from URL parameters


### PR DESCRIPTION
Removing ?v=10 allows build.js to correctly hash and reference the files. Fixes 404 errors on production build.